### PR TITLE
 Support self hosting registry without https and custom port.

### DIFF
--- a/modules/utils/fetchNpmPackage.js
+++ b/modules/utils/fetchNpmPackage.js
@@ -1,4 +1,5 @@
 import url from 'url';
+import http from 'http';
 import https from 'https';
 import gunzip from 'gunzip-maybe';
 import tar from 'tar-stream';
@@ -13,14 +14,15 @@ export default function fetchNpmPackage(packageConfig) {
 
     debug('Fetching package for %s from %s', packageConfig.name, tarballURL);
 
-    const { hostname, pathname } = url.parse(tarballURL);
+    const { protocol, hostname, port, pathname } = url.parse(tarballURL);
     const options = {
-      agent: agent,
+      agent: agent[protocol],
       hostname: hostname,
+      port: port,
       path: pathname
     };
 
-    https
+    ((protocol === 'http:') ? http : https)
       .get(options, res => {
         if (res.statusCode === 200) {
           resolve(res.pipe(gunzip()).pipe(tar.extract()));

--- a/modules/utils/registryAgent.js
+++ b/modules/utils/registryAgent.js
@@ -1,7 +1,13 @@
+import http from 'http';
 import https from 'https';
 
-const agent = new https.Agent({
-  keepAlive: true
-});
+const agent = {
+  'http:': new http.Agent({
+    keepAlive: true
+  }),
+  'https:': new https.Agent({
+    keepAlive: true
+  }),
+};
 
 export default agent;


### PR DESCRIPTION
1. Use HTTP without TLS behind Gateway is familiar, But don`t support protocol 'http' now.
2. For custom port support.