### PR TITLE
Add space before `<code>` tag

### DIFF
--- a/modules/client/main/App.js
+++ b/modules/client/main/App.js
@@ -185,7 +185,7 @@ export default class App extends React.Component {
         <p>
           If you omit the file path (i.e. use a &ldquo;bare&rdquo; URL), unpkg
           will serve the file specified by the <code>unpkg</code> field in{' '}
-          <code>package.json</code>, or fall back to
+          <code>package.json</code>, or fall back to{' '}
           <code>main</code>.
         </p>
 


### PR DESCRIPTION
add missing space:

![2019-06-19_19-50-21](https://user-images.githubusercontent.com/6443113/59788261-9c4fc280-92cb-11e9-9e6e-349ab0a6cc9b.png)
