### PR TITLE
Make it more resilient to custom registry resolution

### DIFF
--- a/modules/__mocks__/npmMock.js
+++ b/modules/__mocks__/npmMock.js
@@ -24,10 +24,10 @@ export function getPackageConfig(packageName, version) {
   return info ? info.versions[version] : null;
 }
 
-export function getPackage(packageName, version) {
+export function getPackage(packageConfig) {
   const file = path.resolve(
     __dirname,
-    `./packages/${packageName}-${version}.tgz`
+    `./packages/${packageConfig.name}-${packageConfig.version}.tgz`
   );
 
   return fs.existsSync(file) ? fs.createReadStream(file).pipe(gunzip()) : null;

--- a/modules/actions/serveDirectoryBrowser.js
+++ b/modules/actions/serveDirectoryBrowser.js
@@ -65,7 +65,7 @@ async function findMatchingEntries(stream, filename) {
 }
 
 async function serveDirectoryBrowser(req, res) {
-  const stream = await getPackage(req.packageName, req.packageVersion, req.log);
+  const stream = await getPackage(req.packageConfig, req.log);
 
   const filename = req.filename.slice(0, -1) || '/';
   const entries = await findMatchingEntries(stream, filename);

--- a/modules/actions/serveDirectoryMetadata.js
+++ b/modules/actions/serveDirectoryMetadata.js
@@ -90,7 +90,7 @@ function getMetadata(entry, entries) {
 }
 
 async function serveDirectoryMetadata(req, res) {
-  const stream = await getPackage(req.packageName, req.packageVersion, req.log);
+  const stream = await getPackage(req.packageConfig, req.log);
 
   const filename = req.filename.slice(0, -1) || '/';
   const entries = await findMatchingEntries(stream, filename);

--- a/modules/actions/serveFileBrowser.js
+++ b/modules/actions/serveFileBrowser.js
@@ -53,7 +53,7 @@ async function findEntry(stream, filename) {
 }
 
 async function serveFileBrowser(req, res) {
-  const stream = await getPackage(req.packageName, req.packageVersion, req.log);
+  const stream = await getPackage(req.packageConfig, req.log);
   const entry = await findEntry(stream, req.filename);
 
   if (!entry) {

--- a/modules/actions/serveFileMetadata.js
+++ b/modules/actions/serveFileMetadata.js
@@ -53,7 +53,7 @@ async function findEntry(stream, filename) {
 }
 
 async function serveFileMetadata(req, res) {
-  const stream = await getPackage(req.packageName, req.packageVersion, req.log);
+  const stream = await getPackage(req.packageConfig, req.log);
   const entry = await findEntry(stream, req.filename);
 
   if (!entry) {

--- a/modules/middleware/findEntry.js
+++ b/modules/middleware/findEntry.js
@@ -156,7 +156,7 @@ function searchEntries(stream, filename) {
  * Redirect to the "index" file if a directory was requested.
  */
 async function findEntry(req, res, next) {
-  const stream = await getPackage(req.packageName, req.packageVersion, req.log);
+  const stream = await getPackage(req.packageConfig, req.log);
   const { foundEntry: entry, matchingEntries: entries } = await searchEntries(
     stream,
     req.filename

--- a/modules/utils/npm.js
+++ b/modules/utils/npm.js
@@ -165,13 +165,10 @@ export async function getPackageConfig(packageName, version, log) {
 /**
  * Returns a stream of the tarball'd contents of the given package.
  */
-export async function getPackage(packageName, version, log) {
-  const tarballName = isScopedPackageName(packageName)
-    ? packageName.split('/')[1]
-    : packageName;
-  const tarballURL = `${npmRegistryURL}/${packageName}/-/${tarballName}-${version}.tgz`;
+export async function getPackage(packageConfig, log) {
+  const tarballURL = packageConfig.dist.tarball;
 
-  log.debug('Fetching package for %s from %s', packageName, tarballURL);
+  log.debug('Fetching package for %s from %s', packageConfig.name, tarballURL);
 
   const { hostname, pathname } = url.parse(tarballURL);
   const options = {
@@ -196,8 +193,8 @@ export async function getPackage(packageName, version, log) {
 
   log.error(
     'Error fetching tarball for %s@%s (status: %s)',
-    packageName,
-    version,
+    packageConfig.name,
+    packageConfig.version,
     res.statusCode
   );
   log.error(content);

--- a/modules/utils/npm.js
+++ b/modules/utils/npm.js
@@ -46,11 +46,12 @@ async function fetchPackageInfo(packageName, log) {
 
   log.debug('Fetching package info for %s from %s', packageName, infoURL);
 
-  const { hostname, pathname } = url.parse(infoURL);
+  const { hostname, pathname, port } = url.parse(infoURL);
   const options = {
     agent: agent,
     hostname: hostname,
     path: pathname,
+    port,
     headers: {
       Accept: 'application/json'
     }
@@ -170,11 +171,12 @@ export async function getPackage(packageConfig, log) {
 
   log.debug('Fetching package for %s from %s', packageConfig.name, tarballURL);
 
-  const { hostname, pathname } = url.parse(tarballURL);
+  const { hostname, pathname, port } = url.parse(tarballURL);
   const options = {
     agent: agent,
     hostname: hostname,
-    path: pathname
+    path: pathname,
+    port
   };
 
   const res = await get(options);


### PR DESCRIPTION
I'm using a self-host custom registry and am trying to integrate it with self-host unpkg server. Everything works fine but just some small issues.

1. unpkg currently fetch package's tarball by manually constructing the request url with the official npm conventional url. This works fine for the official registry and for most of the custom registry, but it's not technically correct in package manager's perspective and will fail in some rare cases. Both `npm` and `yarn` use the tarball url from the package info data itself under `versions[x.x.x].dist.tarball`. We can use the value there instead to better align with the resolution logic of package managers.

2. When fetching the package info, we should also respect the registry `port`. Not all registry are hosted under port `443`. 😅 

The changes here should be fully backward-compatible, and I can verify that it works for my custom registry as well.

I'm not sure if this project ever want to support custom registry? If not then it makes perfect sense to not merge this PR :).

Big shout out to @KevinSheedy for his PR in #216. It helps me to find out the root cause for this PR sooner.