### PR TITLE
Allow specifying extension of files to get

### DIFF
--- a/modules/__tests__/regularFile-test.js
+++ b/modules/__tests__/regularFile-test.js
@@ -48,3 +48,22 @@ describe('A request for a JavaScript file', () => {
     });
   });
 });
+
+describe('A request for a non-JavaScript file', () => {
+  let server;
+  beforeEach(() => {
+    server = createServer();
+  });
+
+  describe('finds typescript file in folder', () => {
+    it.skip('and redirects to it', done => {
+      request(server)
+        .get('/rxjs@7.2.0/dist/types/operators?extension=d.ts')
+        .end((err, res) => {
+          expect(res.statusCode).toBe(302);
+          expect(res.headers.location).toBe('/rxjs@7.2.0/dist/types/operators/index.d.ts');
+          done();
+        });
+    });
+  });
+});

--- a/modules/createServer.js
+++ b/modules/createServer.js
@@ -113,7 +113,7 @@ export default function createServer() {
 
       app.get(
         '*',
-        allowQuery('module'),
+        allowQuery(['module', 'extension']),
         validatePackagePathname,
         validatePackageName,
         validatePackageVersion,
@@ -138,7 +138,7 @@ export default function createServer() {
 
     app.get(
       '*',
-      noQuery(),
+      allowQuery('extension'),
       validatePackagePathname,
       validatePackageName,
       validatePackageVersion,

--- a/modules/utils/__tests__/createSearch-test.js
+++ b/modules/utils/__tests__/createSearch-test.js
@@ -14,6 +14,10 @@ describe('createSearch', () => {
     expect(createSearch({ b: 'b', a: 'a', c: 'c' })).toEqual('?a=a&b=b&c=c');
   });
 
+  it('handles array query correctly', () => {
+    expect(createSearch({ ext: ['d.ts', 'ts'], a: 'a' })).toEqual('?a=a&ext=d.ts&ext=ts');
+  });
+
   it('returns an empty string when there are no params', () => {
     expect(createSearch({})).toEqual('');
   });

--- a/modules/utils/createSearch.js
+++ b/modules/utils/createSearch.js
@@ -1,12 +1,14 @@
 export default function createSearch(query) {
   const keys = Object.keys(query).sort();
   const pairs = keys.reduce(
-    (memo, key) =>
-      memo.concat(
-        query[key] == null || query[key] === ''
+    (memo, key) => {
+      const queryParts = Array.isArray(query[key]) ? query[key] : [query[key]];
+      return memo.concat(
+        ...queryParts.map(part => part == null || part === ''
           ? key
-          : `${key}=${encodeURIComponent(query[key])}`
-      ),
+          : `${key}=${encodeURIComponent(part)}`)
+      );
+    },
     []
   );
 


### PR DESCRIPTION
Fixes https://github.com/mjackson/unpkg/issues/292 and https://github.com/microsoft/TypeScript-Website/issues/1316

This change allows the user to specify what extensions the file requested should be instead of the current default `js`.
This enables the typescript playground to get typescript files that are in a folder.

This `//www.unpkg.com/rxjs@7.2.0/dist/types/operators?extension=ts&extension=d.ts` will now result in `//www.unpkg.com/rxjs@7.2.0/dist/types/operators/index.d.ts?extension=ts&extension=d.ts`

PS: I could not get `regularFile-test.js` to work because of the `Unexpected error in validateVersion!` error thus this test is skipped.