### PR TITLE
Fix semver npm docs broken link on homepage

### DIFF
--- a/modules/client/main/App.js
+++ b/modules/client/main/App.js
@@ -180,7 +180,7 @@ export default function App() {
 
           <p>
             You may also use a{' '}
-            <Link href="https://docs.npmjs.com/misc/semver">semver range</Link>{' '}
+            <Link href="https://docs.npmjs.com/about-semantic-versioning">semver range</Link>{' '}
             or a <Link href="https://docs.npmjs.com/cli/dist-tag">tag</Link>{' '}
             instead of a fixed version number, or omit the version/tag entirely
             to use the <code>latest</code> tag.


### PR DESCRIPTION
This [semver link](https://docs.npmjs.com/misc/semver) on homepage routes to `https://docs.npmjs.com/misc/semver` which gives a 404. 

![image](https://user-images.githubusercontent.com/12623498/136250445-51e039df-caaa-4825-8bf4-6d390d20c84c.png)

This PR replaces that link with `https://docs.npmjs.com/about-semantic-versioning`.

There were two choices for the link:

1. https://docs.npmjs.com/about-semantic-versioning
2. https://docs.npmjs.com/cli/v6/using-npm/semver

I have chosen the first one which is a generalized doc link. The second link routes to a npm package that appears to be a legacy release.